### PR TITLE
Hotfix: Fix styling and usability issues

### DIFF
--- a/apps/website/src/app/main/navigationbar/navigationbar.component.html
+++ b/apps/website/src/app/main/navigationbar/navigationbar.component.html
@@ -60,7 +60,7 @@
       <li>
           <a class="roomselector">
             <fa-icon [icon]="roomsSelectIcon"></fa-icon>
-            <span>
+            <span class="tw-w-full">
               <app-room-select></app-room-select>
             </span>
          </a>

--- a/apps/website/src/app/main/navigationbar/navigationbar.component.html
+++ b/apps/website/src/app/main/navigationbar/navigationbar.component.html
@@ -1,6 +1,11 @@
 
   <nav class="nav-menu">
-    <ul>
+    <ul
+      [class.websocket-disconnected]="isDisconnected"
+      [class.websocket-connection-error]="isConnectionError"
+      [class.websocket-connected]="isConnected"
+      [class.websocket-connecting]="isConnecting"
+    >
       <li>
         <a routerLink="home" routerLinkActive="active">
           <fa-icon [icon]="homeIcon"></fa-icon>
@@ -29,14 +34,26 @@
         <a (click)="$event.preventDefault()" href="">
           <fa-icon [icon]="controlsIcon"></fa-icon>
           <span class="actions">
-                <fa-icon [class.disabled]="minimumBrightnessReached" (click)="this.decreaseBrightness()"
-                         [icon]="decreaseBrightnessIcon"></fa-icon>
-                <fa-icon [class.disabled]="maximumBrightnessReached" (click)="this.increaseBrightness()"
-                         [icon]="increaseBrightnessIcon"></fa-icon>
-                <fa-icon [class.disabled]="minimumSpeedReached" (click)="this.decreaseSpeed()"
-                         [icon]="speedDecreaseIcon"></fa-icon>
-                <fa-icon [class.disabled]="maximumSpeedReached" (click)="this.increaseSpeed()"
-                         [icon]="speedIncreaseIcon"></fa-icon>
+                <fa-icon
+                  [class.disabled]="minimumBrightnessReached"
+                  (click)="this.decreaseBrightness()"
+                  [icon]="decreaseBrightnessIcon">
+                </fa-icon>
+                <fa-icon
+                  [class.disabled]="maximumBrightnessReached"
+                  (click)="this.increaseBrightness()"
+                  [icon]="increaseBrightnessIcon">
+                </fa-icon>
+                <fa-icon
+                  [class.disabled]="minimumSpeedReached"
+                  (click)="this.decreaseSpeed()"
+                  [icon]="speedDecreaseIcon">
+                </fa-icon>
+                <fa-icon
+                  [class.disabled]="maximumSpeedReached"
+                  (click)="this.increaseSpeed()"
+                  [icon]="speedIncreaseIcon">
+                </fa-icon>
             </span>
         </a>
       </li>

--- a/apps/website/src/app/main/navigationbar/navigationbar.component.scss
+++ b/apps/website/src/app/main/navigationbar/navigationbar.component.scss
@@ -12,7 +12,7 @@
       white-space: nowrap;
     }
 
-    &.websocket-disconnected li a, .websocket-connection-error li a{
+    &.websocket-disconnected li a, &.websocket-connection-error li a{
       @apply tw-border-error;
     }
 

--- a/apps/website/src/app/main/navigationbar/navigationbar.component.scss
+++ b/apps/website/src/app/main/navigationbar/navigationbar.component.scss
@@ -1,19 +1,35 @@
 #powerOff, #powerOffMobile {
   &:hover {
-    @apply tw-bg-error tw-text-error-content;
+    @apply tw-bg-error tw-border-error tw-text-error-content;
   }
 }
 
 /* Desktop Navigation */
 .nav-menu {
-  ul li {
-    position: relative;
-    white-space: nowrap;
+  ul {
+    li {
+      position: relative;
+      white-space: nowrap;
+    }
+
+    &.websocket-disconnected li a, .websocket-connection-error li a{
+      @apply tw-border-error;
+    }
+
+    &.websocket-connected li a{
+      @apply tw-border-success;
+    }
+
+    &.websocket-connecting li a{
+      @apply tw-border-blue-600;
+    }
   }
 
   a {
     @apply
     tw-bg-base-300
+    tw-border-base-300
+    tw-border-2
     tw-text-base-content
     tw-flex
     tw-items-center
@@ -33,6 +49,7 @@
     &:hover {
       @apply
       tw-bg-primary
+      tw-border-primary
       tw-text-primary-content;
     }
 

--- a/apps/website/src/app/main/navigationbar/navigationbar.component.ts
+++ b/apps/website/src/app/main/navigationbar/navigationbar.component.ts
@@ -1,42 +1,45 @@
-import { Component, Input, ViewChild } from "@angular/core";
+import {Component, Input, ViewChild} from '@angular/core';
 import {
   faChartBar,
   faCog,
   faEyeDropper,
   faHome,
   faList,
-  faMinus, faObjectGroup,
+  faMinus,
+  faObjectGroup,
   faPlus,
   faPowerOff,
   faRunning,
   faSlidersH,
   faWalking
 } from '@fortawesome/free-solid-svg-icons';
-import { Store } from "@ngrx/store";
-import { ColorpickerComponent } from "../../shared/components/colorpicker/colorpicker.component";
-import { LedstripState } from "@angulon/interfaces";
-import { WebsocketService } from "../../services/websocketconnection/websocket.service";
+import {Store} from '@ngrx/store';
+import {ColorpickerComponent} from '../../shared/components/colorpicker/colorpicker.component';
+import {LedstripState} from '@angulon/interfaces';
+import {WebsocketService} from '../../services/websocketconnection/websocket.service';
 import {
   DecreaseLedstripBrightness,
   DecreaseLedstripSpeed,
   IncreaseLedstripBrightness,
   IncreaseLedstripSpeed
-} from "../../../redux/ledstrip/ledstrip.action";
+} from '../../../redux/ledstrip/ledstrip.action';
 import {
   MAXIMUM_BRIGHTNESS,
   MINIMUM_BRIGHTNESS,
   SPEED_MAXIMUM_INTERVAL_MS,
   SPEED_MINIMUM_INTERVAL_MS
-} from "../../shared/constants";
+} from '../../shared/constants';
+import {ClientNetworkState, WebsocketConnectionStatus} from '../../../redux/networkstate/ClientNetworkState';
+import {distinctUntilChanged, map} from 'rxjs';
 
 @Component({
-  selector: "app-navigationbar",
-  templateUrl: "./navigationbar.component.html",
-  styleUrls: ["./navigationbar.component.scss"]
+  selector: 'app-navigationbar',
+  templateUrl: './navigationbar.component.html',
+  styleUrls: ['./navigationbar.component.scss']
 })
 export class NavigationbarComponent {
   @ViewChild(ColorpickerComponent) colorpicker!: ColorpickerComponent;
-  @Input() colorPickerOrientation: "horizontal" | "vertical" = "horizontal";
+  @Input() colorPickerOrientation: 'horizontal' | 'vertical' = 'horizontal';
 
   readonly homeIcon = faHome;
   readonly modeIcon = faList;
@@ -56,17 +59,57 @@ export class NavigationbarComponent {
   maximumBrightnessReached = false;
   maximumSpeedReached = false;
 
+  websocketConnectionStatus: WebsocketConnectionStatus | undefined;
+  clearConnectionStatusTimeout: NodeJS.Timeout | undefined;
+  get isDisconnected(): boolean {
+    return this.websocketConnectionStatus === WebsocketConnectionStatus.DISCONNECTED;
+  };
+
+  get isConnecting(): boolean {
+    return this.websocketConnectionStatus === WebsocketConnectionStatus.CONNECTING;
+  }
+
+  get isConnected(): boolean {
+    return this.websocketConnectionStatus === WebsocketConnectionStatus.CONNECTED;
+  }
+
+  get isConnectionError(): boolean {
+    return this.websocketConnectionStatus === WebsocketConnectionStatus.CONNECTERROR;
+  }
+
+
 
   constructor(
     public connection: WebsocketService,
-    private store: Store<{ ledstripState: LedstripState }>
+    private store: Store<{
+      ledstripState: LedstripState,
+      networkState: ClientNetworkState
+    }>
   ) {
-    store.select("ledstripState").subscribe(state => {
+    store.select('ledstripState').subscribe(state => {
       this.minimumBrightnessReached = state.brightness === MINIMUM_BRIGHTNESS;
       this.minimumSpeedReached = state.speed === SPEED_MINIMUM_INTERVAL_MS;
       this.maximumBrightnessReached = state.brightness === MAXIMUM_BRIGHTNESS;
       this.maximumSpeedReached = state.speed === SPEED_MAXIMUM_INTERVAL_MS;
     });
+
+    // Subscribe to change in the networkstate.connectionstatus only when that property changes
+    store.select('networkState')
+      .pipe(
+        distinctUntilChanged((prev, curr) => prev.connectionStatus === curr.connectionStatus),
+        map(state => state.connectionStatus)
+      )
+      .subscribe(connectionStatus => {
+        this.websocketConnectionStatus = connectionStatus;
+
+        // After 5 seconds, clear the connection status so all visuals are removed
+        if (this.clearConnectionStatusTimeout) {
+          clearTimeout(this.clearConnectionStatusTimeout);
+        }
+        this.clearConnectionStatusTimeout = setTimeout(() => {
+          this.websocketConnectionStatus = undefined;
+        }, 5000);
+      });
   }
 
   turnOff(): void {

--- a/apps/website/src/app/main/navigationbar/navigationbar.component.ts
+++ b/apps/website/src/app/main/navigationbar/navigationbar.component.ts
@@ -61,6 +61,7 @@ export class NavigationbarComponent {
 
   websocketConnectionStatus: WebsocketConnectionStatus | undefined;
   clearConnectionStatusTimeout: NodeJS.Timeout | undefined;
+
   get isDisconnected(): boolean {
     return this.websocketConnectionStatus === WebsocketConnectionStatus.DISCONNECTED;
   };
@@ -76,7 +77,6 @@ export class NavigationbarComponent {
   get isConnectionError(): boolean {
     return this.websocketConnectionStatus === WebsocketConnectionStatus.CONNECTERROR;
   }
-
 
 
   constructor(
@@ -106,9 +106,10 @@ export class NavigationbarComponent {
         if (this.clearConnectionStatusTimeout) {
           clearTimeout(this.clearConnectionStatusTimeout);
         }
-        this.clearConnectionStatusTimeout = setTimeout(() => {
-          this.websocketConnectionStatus = undefined;
-        }, 5000);
+
+        if (this.websocketConnectionStatus === WebsocketConnectionStatus.CONNECTED) {
+          this.clearConnectionStatusTimeout = setTimeout(() => this.websocketConnectionStatus = undefined, 5000);
+        }
       });
   }
 

--- a/apps/website/src/app/pages/settings-page/settings-page.component.html
+++ b/apps/website/src/app/pages/settings-page/settings-page.component.html
@@ -61,7 +61,7 @@
                       #submitRoomButton
                       (click)="createRoom(roomName.value)"
                       disabled
-                      class="tw-btn tw-join-item tw-w-1/2">
+                      class="tw-btn tw-btn-primary tw-join-item tw-w-1/2">
                       <span *ngIf="roomName.value.length === 0; else roomNameAvailable">Enter a room name</span>
                       <ng-template #roomNameAvailable>Create New Room</ng-template>
                     </button>

--- a/apps/website/src/app/pages/settings-page/settings-page.component.ts
+++ b/apps/website/src/app/pages/settings-page/settings-page.component.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {faGripLines, faTrash} from '@fortawesome/free-solid-svg-icons';
+import {faTrash} from '@fortawesome/free-solid-svg-icons';
 import {GeneralSettings, UserPreferences} from '../../shared/types/types';
 import {themes} from '../../shared/constants';
 import {Store} from '@ngrx/store';

--- a/apps/website/src/app/services/websocketconnection/websocket.service.ts
+++ b/apps/website/src/app/services/websocketconnection/websocket.service.ts
@@ -16,10 +16,10 @@ import { ChangeMultipleLedstripProperties, ReceiveServerLedstripState } from '..
 import { LoadModesAction } from '../../../redux/modes/modes.action';
 import { LoadGradientsAction } from '../../../redux/gradients/gradients.action';
 import iro from '@jaames/iro';
-import { LoadNetworkState } from '../../../redux/networkstate/networkstate.action';
+import {LoadNetworkState, NetworkConnectionStatusChange} from '../../../redux/networkstate/networkstate.action';
 import { UserPreferences } from '../../shared/types/types';
 import { first } from 'rxjs';
-import { ClientNetworkState } from '../../../redux/networkstate/ClientNetworkState';
+import { ClientNetworkState, WebsocketConnectionStatus } from '../../../redux/networkstate/ClientNetworkState';
 
 @Injectable({
   providedIn: 'root'
@@ -56,15 +56,18 @@ export class WebsocketService {
         this.loadModes();
         this.loadGradients();
         this.loadNetworkState().then();
+        this.store.dispatch(new NetworkConnectionStatusChange(WebsocketConnectionStatus.CONNECTED));
       });
 
       this.socket.on('disconnect', () => {
         console.log(`Disconnected from websocket at ${this.websocketUrl}`);
+        this.store.dispatch(new NetworkConnectionStatusChange(WebsocketConnectionStatus.DISCONNECTED));
       });
 
       this.socket.on('connect_error', (error: Error) => {
         console.error(`Failed to connect to websocket at ${this.websocketUrl}`, error);
         messageService.setMessage(error);
+        this.store.dispatch(new NetworkConnectionStatusChange(WebsocketConnectionStatus.CONNECTERROR));
       });
 
       this.socket.on(WebsocketMessage.StateChange, (state: LedstripState) => this.updateAppState(state));

--- a/apps/website/src/app/services/websocketconnection/websocket.service.ts
+++ b/apps/website/src/app/services/websocketconnection/websocket.service.ts
@@ -44,7 +44,6 @@ export class WebsocketService {
       .subscribe((userPreferences) => {
       this.socket = io(this.websocketUrl, {
         transports: ['websocket'],
-        reconnectionAttempts: 5,
         query: {
           deviceName: userPreferences.settings.deviceName
         }

--- a/apps/website/src/app/shared/components/device/device.component.html
+++ b/apps/website/src/app/shared/components/device/device.component.html
@@ -1,17 +1,18 @@
-<div class="tw-bg-base-200 tw-p-4 tw-rounded device">
-            <span
-              [ngClass]="device.isConnected ? 'tw-bg-success' : 'tw-bg-error'"
-              [title]="device.isConnected ? 'Connected' : 'Not Connected'"
-              class="network-indicator">
-            </span>
-  <h3 class="tw-text-center">{{device.name}}</h3>
-  <hr>
+<div class="tw-bg-base-200 tw-text-base-content tw-p-4 tw-rounded device">
+  <span
+    [ngClass]="device.isConnected ? 'tw-bg-success' : 'tw-bg-error'"
+    [title]="device.isConnected ? 'Connected' : 'Not Connected'"
+    class="network-indicator">
+  </span>
 
-  <div class="tw-grid tw-grid-cols-2 tw-mt-2" *ngIf="!compact">
-    <div class="tw-text-end">Is Connected:</div>
-    <div class="tw-pl-2">{{device.isConnected | yesNo}}</div>
+  <div class="tw-divide-y tw-divide-accent">
+    <h3 class="tw-text-center">{{ device.name }}</h3>
+    <div class="tw-grid tw-grid-cols-2 tw-pt-2" *ngIf="!compact">
+      <div class="tw-text-end">Is Connected:</div>
+      <div class="tw-pl-2">{{ device.isConnected | yesNo }}</div>
 
-    <div class="tw-text-end">Is Ledstrip:</div>
-    <div class="tw-pl-2">{{device.isLedstrip | yesNo}}</div>
+      <div class="tw-text-end">Is Ledstrip:</div>
+      <div class="tw-pl-2">{{ device.isLedstrip | yesNo }}</div>
+    </div>
   </div>
 </div>

--- a/apps/website/src/app/shared/components/room-select/room-select.component.html
+++ b/apps/website/src/app/shared/components/room-select/room-select.component.html
@@ -1,25 +1,28 @@
 <ng-container *ngIf="networkState && networkState.rooms.length > 0; else noRooms">
-  <div *ngFor="let room of networkState.rooms" class="tw-my-1">
+  <div *ngFor="let room of networkState.rooms" class="tw-my-1 tw-w-full">
     <div
       class="room"
       [class.selected]="isRoomSelected(room)"
     >
-      <div class="tw-flex tw-justify-between tw-w-full">
-        <div>
-          <h2>{{ room.name }}</h2>
-          <p>Assigned: {{ room.connectedDevices.length }}</p>
-          <p *ngIf="getOfflineDevicesCount(room) > 0">
-            <fa-icon class="tw-text-warning" [icon]="offlineWarningIcon"></fa-icon>
-            Offline: {{ getOfflineDevicesCount(room) }}
-          </p>
+      <label for="roomCheckbox{{room.id}}" class="tw-cursor-pointer">
+        <div class="tw-flex tw-justify-between md:tw-min-w-32">
+          <div>
+            <h2>{{ room.name }}</h2>
+            <p>Assigned: {{ room.connectedDevices.length }}</p>
+            <p *ngIf="getOfflineDevicesCount(room) > 0">
+              <fa-icon class="tw-text-warning" [icon]="offlineWarningIcon"></fa-icon>
+              Offline: {{ getOfflineDevicesCount(room) }}
+            </p>
+          </div>
+          <div class="tw-flex tw-justify-center">
+            <input id="roomCheckbox{{room.id}}"
+                   type="checkbox"
+                   [checked]="isRoomSelected(room)"
+                   (change)="onRoomSelectionChanged($event, room)"
+                   class="checkbox"/>
+          </div>
         </div>
-        <div class="tw-flex tw-justify-center">
-          <input type="checkbox"
-                 [checked]="isRoomSelected(room)"
-                 (change)="onRoomSelectionChanged($event, room)"
-                 class="checkbox"/>
-        </div>
-      </div>
+      </label>
     </div>
   </div>
 </ng-container>

--- a/apps/website/src/app/shared/components/room-select/room-select.component.html
+++ b/apps/website/src/app/shared/components/room-select/room-select.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="networkState">
+<ng-container *ngIf="networkState && networkState.rooms.length > 0; else noRooms">
   <div *ngFor="let room of networkState.rooms" class="tw-my-1">
     <div
       class="room"
@@ -14,9 +14,16 @@
           </p>
         </div>
         <div class="tw-flex tw-justify-center">
-          <input type="checkbox" [checked]="isRoomSelected(room)" (change)="onRoomSelectionChanged($event, room)" class="checkbox"/>
+          <input type="checkbox"
+                 [checked]="isRoomSelected(room)"
+                 (change)="onRoomSelectionChanged($event, room)"
+                 class="checkbox"/>
         </div>
       </div>
     </div>
   </div>
-</div>
+</ng-container>
+
+<ng-template #noRooms>
+  <p>No rooms available</p>
+</ng-template>

--- a/apps/website/src/app/shared/components/room-select/room-select.component.scss
+++ b/apps/website/src/app/shared/components/room-select/room-select.component.scss
@@ -1,6 +1,5 @@
 .room {
   @apply
-  tw-w-72
   tw-bg-neutral
   tw-rounded-full
   tw-p-3

--- a/apps/website/src/redux/networkstate/ClientNetworkState.ts
+++ b/apps/website/src/redux/networkstate/ClientNetworkState.ts
@@ -1,8 +1,16 @@
 import {INetworkState, IRoom} from '@angulon/interfaces';
 
+export enum WebsocketConnectionStatus {
+  CONNECTING = 'CONNECTING',
+  CONNECTED = 'CONNECTED',
+  DISCONNECTED = 'DISCONNECTED',
+  CONNECTERROR = 'CONNECTERROR',
+}
+
 /**
  * Type to extend the INetworkState interface which allows for an additional properties to be added that only live on each client
  */
 export interface ClientNetworkState extends INetworkState {
   selectedRooms: IRoom[];
+  connectionStatus: WebsocketConnectionStatus;
 }

--- a/apps/website/src/redux/networkstate/networkstate.action.ts
+++ b/apps/website/src/redux/networkstate/networkstate.action.ts
@@ -1,10 +1,12 @@
 import {INetworkState, IRoom} from '@angulon/interfaces';
 import {Action} from '@ngrx/store';
+import {WebsocketConnectionStatus} from './ClientNetworkState';
 
 export enum NetworkstateAction {
   LOAD_NETWORK_STATE = 'LOAD_NETWORK_STATE',
   SELECT_ROOM = 'SELECT_ROOM',
-  UNSELECT_ROOM = 'UNSELECT_ROOM'
+  UNSELECT_ROOM = 'UNSELECT_ROOM',
+  NETWORKCONNECTIONSTATUSCHANGE = 'NETWORKCONNECTIONSTATUSCHANGE',
 }
 
 export class LoadNetworkState implements Action {
@@ -25,5 +27,12 @@ export class UnselectRoom implements Action {
   readonly type = NetworkstateAction.UNSELECT_ROOM;
 
   constructor(public payload: IRoom) {
+  }
+}
+
+export class NetworkConnectionStatusChange implements Action {
+  readonly type = NetworkstateAction.NETWORKCONNECTIONSTATUSCHANGE;
+
+  constructor(public payload: WebsocketConnectionStatus) {
   }
 }

--- a/apps/website/src/redux/networkstate/networkstate.reducer.ts
+++ b/apps/website/src/redux/networkstate/networkstate.reducer.ts
@@ -1,5 +1,5 @@
 import {NetworkstateAction} from './networkstate.action';
-import {ClientNetworkState} from './ClientNetworkState';
+import {ClientNetworkState, WebsocketConnectionStatus} from './ClientNetworkState';
 import {loadObjectFromLocalStorage} from '../../app/shared/functions';
 import {IRoom} from '@angulon/interfaces';
 
@@ -11,7 +11,8 @@ const selectedRoomsFromLocalStorage = loadObjectFromLocalStorage('selectedRooms'
 const initialState: ClientNetworkState = {
   rooms: [],
   devices: [],
-  selectedRooms: selectedRoomsFromLocalStorage
+  selectedRooms: selectedRoomsFromLocalStorage,
+  connectionStatus: WebsocketConnectionStatus.DISCONNECTED
 };
 
 export const networkStateReducer = (state: ClientNetworkState = initialState, action: any): ClientNetworkState => {
@@ -42,6 +43,12 @@ export const networkStateReducer = (state: ClientNetworkState = initialState, ac
       return {
         ...state,
         selectedRooms: newSelectedRooms
+      };
+    }
+    case NetworkstateAction.NETWORKCONNECTIONSTATUSCHANGE: {
+      return {
+        ...state,
+        connectionStatus: action.payload
       };
     }
     default:

--- a/apps/website/src/styles.scss
+++ b/apps/website/src/styles.scss
@@ -34,4 +34,12 @@
     background: hsl(var(--a)) !important;
   }
 }
+
+
+// The default style of disabled DaisyUI button component is very difficult to read due to low contrast
+.tw-btn:disabled {
+  @apply tw-text-neutral-100;
+  filter: brightness(0.6);
+}
+
 @import 'aos/dist/aos.css';

--- a/apps/website/tailwind.config.js
+++ b/apps/website/tailwind.config.js
@@ -1,5 +1,5 @@
-const { createGlobPatternsForDependencies } = require('@nx/angular/tailwind');
-const { join } = require('path');
+const {createGlobPatternsForDependencies} = require('@nx/angular/tailwind');
+const {join} = require('path');
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
@@ -21,7 +21,10 @@ module.exports = {
       },
       borderRadius: {
         '2xl': '50px'
-      }
+      },
+      minWidth: {
+        '32': '8rem',
+      },
     }
   },
   daisyui: {


### PR DESCRIPTION
# Added
- Show connection status through a border around the navigation bar items

# Changed

# Fixed
- Room selection not possible on phones because checkbox fell off the screen
- Fixed ugly/unreadable styling of showing devices in light themes.
- Fixed unreadable disabled buttons

# Improved
- You no longer need to precisely click the checkbox, but can now select the entire room row instead to tick it.