### PR TITLE
Hotfix: Updating room state only updated one room, even when multiple rooms were selected

### DIFF
--- a/apps/api/src/app/device/device.service.ts
+++ b/apps/api/src/app/device/device.service.ts
@@ -30,7 +30,7 @@ export class DeviceService implements DAOService<Device> {
     return this.deviceRepository.save(device);
   }
 
-  async update(criteria: FindOptionsWhere<Device>, deviceData: Partial<Device>): Promise<Device> {
+  async updateOne(criteria: FindOptionsWhere<Device>, deviceData: Partial<Device>): Promise<Device> {
     const existingDevice = await this.deviceRepository.findOne({ where: criteria });
     if (!existingDevice) return null;
 
@@ -55,7 +55,7 @@ export class DeviceService implements DAOService<Device> {
   async createOrUpdate(criteria: FindOneOptions<Device>, entity: Partial<Device>): Promise<Device> {
     const existingDevice = await this.findOne(criteria);
     if (existingDevice) {
-      await this.update(criteria.where as FindOptionsWhere<Device>, entity);
+      await this.updateOne(criteria.where as FindOptionsWhere<Device>, entity);
       return existingDevice;
     }
 
@@ -69,7 +69,7 @@ export class DeviceService implements DAOService<Device> {
    */
   async renameDevice(sessionId: string, payload: string) {
     this.logger.log(`Renaming device with session id ${sessionId} to ${payload}`);
-    await this.update({ socketSessionId: sessionId }, { name: payload });
+    await this.updateOne({ socketSessionId: sessionId }, { name: payload });
   }
 
   async estimatePowerDrawForAllOnlineLedstrips(): Promise<Record<string, number>> {

--- a/apps/api/src/app/interfaces/DAOService.ts
+++ b/apps/api/src/app/interfaces/DAOService.ts
@@ -4,7 +4,7 @@ export interface DAOService<Entity> {
   findAll(criteria?: FindManyOptions<Entity>): Promise<Entity[]>;
   findOne(criteria: FindOneOptions<Entity>): Promise<Entity>;
   create(entityData: Partial<Entity>): Promise<Entity>;
-  update(criteria: FindOptionsWhere<Entity>, entityData: Partial<Entity>): Promise<Entity>;
+  updateOne(criteria: FindOptionsWhere<Entity>, entityData: Partial<Entity>): Promise<Entity>;
   remove(criteria: FindManyOptions<Entity>): Promise<void>;
   validate(entityData: Partial<Entity>): Promise<void>;
   createOrUpdate(criteria: FindOneOptions<Entity>, entity: Partial<Entity>): Promise<Entity>

--- a/apps/api/src/app/websocket/websocket.service.ts
+++ b/apps/api/src/app/websocket/websocket.service.ts
@@ -85,7 +85,7 @@ export class WebsocketService {
   async joinUserRoom(client: Socket) {
     client.join('user');
     // delete this device from the database because it is now a user
-    await this.deviceService.update({socketSessionId: client.id}, {isLedstrip: false});
+    await this.deviceService.updateOne({socketSessionId: client.id}, {isLedstrip: false});
     this.logger.log(`The client ${client.id} registered as a user`);
   }
 
@@ -118,7 +118,7 @@ export class WebsocketService {
 
     // If the device is already in the database, update the socketSessionId and isConnected fields. Also join the room if it is in one
     if (deviceInDb) {
-      await this.deviceService.update({name: deviceName}, {socketSessionId: client.id, isConnected: true, ledCount: ledCount ? parseInt(ledCount) : 0});
+      await this.deviceService.updateOne({name: deviceName}, {socketSessionId: client.id, isConnected: true, ledCount: ledCount ? parseInt(ledCount) : 0});
 
       if (deviceInDb.room) {
         client.join(deviceInDb.room.id);
@@ -150,7 +150,7 @@ export class WebsocketService {
    */
   onDisconnect(client: Socket, server: Server) {
     this.logger.log(`Client ${client.id} went offline`);
-    this.deviceService.update({socketSessionId: client.id}, {isConnected: false}).then();
+    this.deviceService.updateOne({socketSessionId: client.id}, {isConnected: false}).then();
     this.server = server;
   }
 

--- a/apps/website/src/app/main/navigationbar/navigationbar.component.scss
+++ b/apps/website/src/app/main/navigationbar/navigationbar.component.scss
@@ -71,7 +71,7 @@
   }
 
   .roomselector {
-    @apply tw-h-[275px] md:tw-h-[175px];
+    @apply tw-h-[275px] md:tw-h-[175px] tw-overflow-y-auto;
   }
 
   .active {

--- a/apps/website/src/app/shared/components/power-draw/power-draw.component.html
+++ b/apps/website/src/app/shared/components/power-draw/power-draw.component.html
@@ -1,1 +1,1 @@
-<div echarts [options]="chartOption" [merge]="updateOptions" class="chart"></div>
+<div echarts [options]="chartOption" [merge]="updateOptions" (chartInit)="onChartInit($event)" class="chart"></div>

--- a/apps/website/src/app/shared/components/power-draw/power-draw.component.ts
+++ b/apps/website/src/app/shared/components/power-draw/power-draw.component.ts
@@ -61,11 +61,13 @@ export class PowerDrawComponent implements OnDestroy {
   private getDataInterval: NodeJS.Timeout | undefined;
   private MAXIMUM_DATA_POINTS = 30;
   private POLLING_INTERVAL_MS = 1000;
+  private echartsInstance: any;
 
   constructor(private readonly websocketService: WebsocketService) {
   }
 
   public startPollingData() {
+    this.echartsInstance.hideLoading();
     this.getDataInterval = setInterval(async () => {
       const powerEstimates = await this.websocketService.getPowerDrawEstimateData();
 
@@ -142,6 +144,11 @@ export class PowerDrawComponent implements OnDestroy {
 
   stopPollingData() {
     clearInterval(this.getDataInterval);
+  }
+
+  onChartInit(instance: any) {
+    this.echartsInstance = instance;
+    this.echartsInstance.showLoading();
   }
 }
 

--- a/apps/website/src/app/shared/components/power-draw/power-draw.component.ts
+++ b/apps/website/src/app/shared/components/power-draw/power-draw.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnDestroy} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {NgxEchartsDirective, provideEcharts} from 'ngx-echarts';
-import {ECElementEvent, EChartsOption, LineSeriesOption} from 'echarts';
+import {EChartsOption, LineSeriesOption} from 'echarts';
 import {WebsocketService} from '../../../services/websocketconnection/websocket.service';
 import {extractThemeColorsFromDOM} from '../../functions';
 import {OptionDataValue} from 'echarts/types/src/util/types';


### PR DESCRIPTION
# Fixed
- Updating room state only updated one room, even when multiple rooms were selected

# Changed
- Power Draw graph displays a loading indication when there is no data yet (e.g. no connection)

# Improved
- Added scrolling to room-selector when amount of rooms configured cause an overflow