### PR TITLE
Fix subscriptions in OnDestroy lifecycle

### DIFF
--- a/apps/api/src/app/room/room.service.ts
+++ b/apps/api/src/app/room/room.service.ts
@@ -1,16 +1,16 @@
-import {Injectable, Logger} from '@nestjs/common';
+import {Injectable, Logger, OnModuleDestroy} from '@nestjs/common';
 import {DAOService} from '../interfaces/DAOService';
 import {Room} from './Room.model';
-import {FindManyOptions, FindOneOptions, FindOptionsWhere, In, Repository} from 'typeorm';
-import {InjectRepository} from '@nestjs/typeorm';
-import {validate} from 'class-validator';
-import {DeviceService} from '../device/device.service';
-import {INITIAL_ROOM_STATE, IRoom, RoomsState, RoomState} from '@angulon/interfaces';
-import {debounceTime, Subject} from 'rxjs';
+import {FindManyOptions, FindOneOptions, FindOptionsWhere, In, Repository}from 'typeorm';
+import {InjectRepository}from '@nestjs/typeorm';
+import {validate}from 'class-validator';
+import {DeviceService}from '../device/device.service';
+import {INITIAL_ROOM_STATE, IRoom, RoomsState, RoomState}from '@angulon/interfaces';
+import {debounceTime, Subject}from 'rxjs';
 
 
 @Injectable()
-export class RoomService implements DAOService<Room> {
+export class RoomService implements DAOService<Room>, OnModuleDestroy {
   private readonly logger = new Logger(RoomService.name);
 
   /**
@@ -139,5 +139,9 @@ export class RoomService implements DAOService<Room> {
    */
   async updateRoomStateForRooms(rooms: string[], newState: RoomState) {
     await this.updateMany({id: In(rooms)}, {state: newState});
+  }
+
+  onModuleDestroy() {
+    this.updateRoomStateForRoomsSubject.unsubscribe();
   }
 }

--- a/apps/website/src/app/main/app/app.component.ts
+++ b/apps/website/src/app/main/app/app.component.ts
@@ -24,7 +24,7 @@ export class AppComponent implements OnInit, OnDestroy {
   @ViewChild('mobileMenu') mobileMenu!: OffCanvasComponent;
   readonly timeline = gsap.timeline();
   private animationMode = 0;
-  private routerSubscription: Subscription;
+  private routerSubscription!: Subscription;
 
   mobileMenuIcon = OpenMobileMenuIcon;
 

--- a/apps/website/src/app/main/app/app.component.ts
+++ b/apps/website/src/app/main/app/app.component.ts
@@ -1,17 +1,18 @@
-import {Component, HostListener, OnInit, ViewChild} from '@angular/core';
+import {Component, HostListener, OnInit, ViewChild, OnDestroy} from '@angular/core';
 import {SwUpdate} from '@angular/service-worker';
 import {MessageService} from '../../services/message-service/message.service';
-import {ThemeService} from '../../services/theme/theme.service';
-import {Message} from '../../shared/types/Message';
-import {swipeRight} from '@angulon/ui';
+import {ThemeService}from '../../services/theme/theme.service';
+import {Message}from '../../shared/types/Message';
+import {swipeRight}from '@angulon/ui';
 import * as AOS from 'aos';
-import {UserPreferences} from '../../shared/types/types';
-import {Store} from '@ngrx/store';
-import {BaseChromaConnection} from '../../services/chroma-sdk/base-chroma-connection.service';
-import {NavigationEnd, NavigationStart, Router} from '@angular/router';
-import {gsap} from 'gsap';
-import {OffCanvasComponent} from '../../shared/components/offcanvas/off-canvas.component';
-import {faBars as OpenMobileMenuIcon, faTimes as CloseMobileMenuIcon} from '@fortawesome/free-solid-svg-icons';
+import {UserPreferences}from '../../shared/types/types';
+import {Store}from '@ngrx/store';
+import {BaseChromaConnection}from '../../services/chroma-sdk/base-chroma-connection.service';
+import {NavigationEnd, NavigationStart, Router}from '@angular/router';
+import {gsap}from 'gsap';
+import {OffCanvasComponent}from '../../shared/components/offcanvas/off-canvas.component';
+import {faBars as OpenMobileMenuIcon, faTimes as CloseMobileMenuIcon}from '@fortawesome/free-solid-svg-icons';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-root',
@@ -19,10 +20,11 @@ import {faBars as OpenMobileMenuIcon, faTimes as CloseMobileMenuIcon} from '@for
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit, OnDestroy {
   @ViewChild('mobileMenu') mobileMenu!: OffCanvasComponent;
   readonly timeline = gsap.timeline();
   private animationMode = 0;
+  private routerSubscription: Subscription;
 
   mobileMenuIcon = OpenMobileMenuIcon;
 
@@ -78,7 +80,7 @@ export class AppComponent implements OnInit {
     AOS.init();
 
     // Subscribe to router events so we can display a page transition animation each time the user navigates to a new page.
-    this.router.events.subscribe((val) => {
+    this.routerSubscription = this.router.events.subscribe((val) => {
       // When the user starts to navigate to a new page, immediately show the cover again otherwise content will already be visible.
       if (val instanceof NavigationStart) {
         gsap.set('#cover', { autoAlpha: 1, duration: 0.3 });
@@ -88,6 +90,10 @@ export class AppComponent implements OnInit {
         this.mobileMenu.close();
       }
     });
+  }
+
+  ngOnDestroy(): void {
+    this.routerSubscription.unsubscribe();
   }
 
   private animationFromLeft(): void {

--- a/apps/website/src/app/main/navigationbar/navigationbar.component.ts
+++ b/apps/website/src/app/main/navigationbar/navigationbar.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, ViewChild} from '@angular/core';
+import {Component, Input, ViewChild, OnDestroy} from '@angular/core';
 import {
   faChartBar,
   faCog,
@@ -30,7 +30,7 @@ import {
   SPEED_MINIMUM_INTERVAL_MS
 } from '../../shared/constants';
 import {ClientNetworkState, WebsocketConnectionStatus} from '../../../redux/networkstate/ClientNetworkState';
-import {distinctUntilChanged, map} from 'rxjs';
+import {distinctUntilChanged, map, Subscription} from 'rxjs';
 import {getStateOfSelectedRooms} from '../../shared/functions';
 
 @Component({
@@ -38,7 +38,7 @@ import {getStateOfSelectedRooms} from '../../shared/functions';
   templateUrl: './navigationbar.component.html',
   styleUrls: ['./navigationbar.component.scss']
 })
-export class NavigationbarComponent {
+export class NavigationbarComponent implements OnDestroy {
   @ViewChild(ColorpickerComponent) colorpicker!: ColorpickerComponent;
   @Input() colorPickerOrientation: 'horizontal' | 'vertical' = 'horizontal';
 
@@ -62,6 +62,8 @@ export class NavigationbarComponent {
 
   websocketConnectionStatus: WebsocketConnectionStatus | undefined;
   clearConnectionStatusTimeout: NodeJS.Timeout | undefined;
+
+  private networkStateSubscription: Subscription;
 
   get isDisconnected(): boolean {
     return this.websocketConnectionStatus === WebsocketConnectionStatus.DISCONNECTED;
@@ -87,7 +89,7 @@ export class NavigationbarComponent {
       networkState: ClientNetworkState
     }>
   ) {
-    store.select('networkState' ).subscribe(state => {
+    this.networkStateSubscription = store.select('networkState' ).subscribe(state => {
       const selectedRoomState = getStateOfSelectedRooms(state);
 
       // When no room is selected, disable all action buttons
@@ -124,6 +126,10 @@ export class NavigationbarComponent {
           this.clearConnectionStatusTimeout = setTimeout(() => this.websocketConnectionStatus = undefined, 5000);
         }
       });
+  }
+
+  ngOnDestroy(): void {
+    this.networkStateSubscription.unsubscribe();
   }
 
   turnOff(): void {

--- a/apps/website/src/app/pages/home-page/home-page.component.ts
+++ b/apps/website/src/app/pages/home-page/home-page.component.ts
@@ -6,12 +6,12 @@ import {DecimalPipe, NgClass, NgForOf, NgIf} from '@angular/common';
 import {RadialProgressComponent} from '../../shared/components/radialprogress/radial-progress.component';
 import {SharedModule}from '../../shared/shared.module';
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import {FontAwesomeModule}from '@fortawesome/free-fontawesome';
 import {PowerDrawComponent}from '../../shared/components/power-draw/power-draw.component';
 import {ClientNetworkState, WebsocketConnectionStatus} from '../../../redux/networkstate/ClientNetworkState';
 import {distinctUntilChanged, map, Subscription} from 'rxjs';
 import { faTrashAlt } from '@fortawesome/free-regular-svg-icons';
 import { WebsocketService } from '../../services/websocketconnection/websocket.service';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 @Component({
   selector: 'app-home',

--- a/apps/website/src/app/pages/home-page/home-page.component.ts
+++ b/apps/website/src/app/pages/home-page/home-page.component.ts
@@ -1,15 +1,15 @@
-import { Component, HostListener, ViewChild } from '@angular/core';
+import { Component, HostListener, ViewChild, OnDestroy } from '@angular/core';
 import { IDevice, IRoom, RoomState } from '@angulon/interfaces';
 import {Store} from '@ngrx/store';
 import {MAXIMUM_BRIGHTNESS, SPEED_MAXIMUM_INTERVAL_MS} from '../../shared/constants';
 import {DecimalPipe, NgClass, NgForOf, NgIf} from '@angular/common';
 import {RadialProgressComponent} from '../../shared/components/radialprogress/radial-progress.component';
-import {SharedModule} from '../../shared/shared.module';
+import {SharedModule}from '../../shared/shared.module';
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import {FontAwesomeModule} from '@fortawesome/angular-fontawesome';
-import {PowerDrawComponent} from '../../shared/components/power-draw/power-draw.component';
+import {FontAwesomeModule}from '@fortawesome/free-fontawesome';
+import {PowerDrawComponent}from '../../shared/components/power-draw/power-draw.component';
 import {ClientNetworkState, WebsocketConnectionStatus} from '../../../redux/networkstate/ClientNetworkState';
-import {distinctUntilChanged, map} from 'rxjs';
+import {distinctUntilChanged, map, Subscription} from 'rxjs';
 import { faTrashAlt } from '@fortawesome/free-regular-svg-icons';
 import { WebsocketService } from '../../services/websocketconnection/websocket.service';
 
@@ -29,7 +29,7 @@ import { WebsocketService } from '../../services/websocketconnection/websocket.s
   ],
   standalone: true
 })
-export class HomePageComponent {
+export class HomePageComponent implements OnDestroy {
   @ViewChild(PowerDrawComponent) powerDrawComponent: PowerDrawComponent | undefined;
   protected readonly faTrash = faTrashAlt;
   protected readonly offlineWarningIcon = faTriangleExclamation;
@@ -39,13 +39,12 @@ export class HomePageComponent {
   private isChartInitialized = false;
   networkState: ClientNetworkState | undefined;
   private contextMenuDevice: IDevice | undefined;
-
-
+  private networkStateSubscription: Subscription;
 
   constructor(
     private readonly store: Store<{ roomState: RoomState, networkState: ClientNetworkState }>,
     private readonly connection: WebsocketService) {
-    this.store.select('networkState').subscribe((state) => {
+    this.networkStateSubscription = this.store.select('networkState').subscribe((state) => {
       this.networkState = state;
     });
 
@@ -61,6 +60,9 @@ export class HomePageComponent {
     });
   }
 
+  ngOnDestroy(): void {
+    this.networkStateSubscription.unsubscribe();
+  }
 
   convertSpeedToPercentage(speed: number) {
     return speed / SPEED_MAXIMUM_INTERVAL_MS * 100;

--- a/apps/website/src/app/pages/settings-page/settings-page.component.ts
+++ b/apps/website/src/app/pages/settings-page/settings-page.component.ts
@@ -1,19 +1,19 @@
-import {Component, OnInit, ViewChild} from '@angular/core';
+import {Component, OnInit, ViewChild, OnDestroy} from '@angular/core';
 import {faTrash} from '@fortawesome/free-solid-svg-icons';
 import {GeneralSettings, UserPreferences} from '../../shared/types/types';
 import {themes} from '../../shared/constants';
-import {Store} from '@ngrx/store';
-import {ChangeGeneralSettings} from '../../../redux/user-preferences/user-preferences.action';
-import {FormsModule, NgForm} from '@angular/forms';
-import {debounceTime, skip} from 'rxjs';
-import {ThemeVisualizationComponent} from '../../shared/components/theme-visualization/theme-visualization.component';
-import {JsonPipe, NgForOf, NgIf} from '@angular/common';
-import {FontAwesomeModule} from '@fortawesome/angular-fontawesome';
-import {IDevice, INetworkState, IRoom} from '@angulon/interfaces';
-import {WebsocketService} from '../../services/websocketconnection/websocket.service';
-import {ActivatedRoute, Router} from '@angular/router';
-import {SharedModule} from '../../shared/shared.module';
-import {CdkDrag, CdkDragDrop, CdkDropList, CdkDropListGroup} from '@angular/cdk/drag-drop';
+import {Store}from '@ngrx/store';
+import {ChangeGeneralSettings}from '../../../redux/user-preferences/user-preferences.action';
+import {FormsModule, NgForm}from '@angular/forms';
+import {debounceTime, skip, Subscription}from 'rxjs';
+import {ThemeVisualizationComponent}from '../../shared/components/theme-visualization/theme-visualization.component';
+import {JsonPipe, NgForOf, NgIf}from '@angular/common';
+import {FontAwesomeModule}from '@fortawesome/angular-fontawesome';
+import {IDevice, INetworkState, IRoom}from '@angulon/interfaces';
+import {WebsocketService}from '../../services/websocketconnection/websocket.service';
+import {ActivatedRoute, Router}from '@angular/router';
+import {SharedModule}from '../../shared/shared.module';
+import {CdkDrag, CdkDragDrop, CdkDropList, CdkDropListGroup}from '@angular/cdk/drag-drop';
 
 @Component({
   selector: 'app-settings',
@@ -33,7 +33,7 @@ import {CdkDrag, CdkDragDrop, CdkDropList, CdkDropListGroup} from '@angular/cdk/
   ],
   standalone: true
 })
-export class SettingsPageComponent implements OnInit {
+export class SettingsPageComponent implements OnInit, OnDestroy {
   @ViewChild('form', {static: true}) form!: NgForm;
   settings: GeneralSettings | undefined;
   selectedTheme = 0;
@@ -42,6 +42,8 @@ export class SettingsPageComponent implements OnInit {
   activeMenu = 0;
   networkState: INetworkState | undefined;
   trashIcon = faTrash;
+  private userPreferencesSubscription: Subscription;
+  private networkStateSubscription: Subscription;
 
   constructor(
     private readonly router: Router,
@@ -51,14 +53,14 @@ export class SettingsPageComponent implements OnInit {
       userPreferences: UserPreferences,
       networkState: INetworkState,
     }>) {
-    this.store.select('userPreferences').subscribe(preferences => {
+    this.userPreferencesSubscription = this.store.select('userPreferences').subscribe(preferences => {
       if (this.skipFormUpdate) return;
 
       this.settings = structuredClone(preferences.settings);
       this.selectedTheme = this.availableThemes.findIndex(theme => theme === preferences.settings.theme);
     });
 
-    this.store.select('networkState').subscribe(networkState => {
+    this.networkStateSubscription = this.store.select('networkState').subscribe(networkState => {
       this.networkState = networkState;
     });
   }
@@ -77,6 +79,11 @@ export class SettingsPageComponent implements OnInit {
         this.activeMenu = parseInt(fragment);
       }
     });
+  }
+
+  ngOnDestroy(): void {
+    this.userPreferencesSubscription.unsubscribe();
+    this.networkStateSubscription.unsubscribe();
   }
 
   setTheme(theme: string): void {

--- a/apps/website/src/app/pages/shortcut-page/shortcut-page.component.ts
+++ b/apps/website/src/app/pages/shortcut-page/shortcut-page.component.ts
@@ -1,9 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from "@angular/router";
 import { MessageService } from '../../services/message-service/message.service';
 import { Store } from '@ngrx/store';
 import { RoomState } from '@angulon/interfaces';
-import { combineLatest } from 'rxjs';
+import { combineLatest, Subscription } from 'rxjs';
 import { WebsocketService } from '../../services/websocketconnection/websocket.service';
 import {
   DecreaseRoomBrightness,
@@ -21,8 +21,9 @@ import {
   ],
   standalone: true
 })
-export class ShortcutPageComponent {
+export class ShortcutPageComponent implements OnDestroy {
   private static wasShortcutActivated = false;
+  private storeSubscription: Subscription;
 
   /**
    * From the query parameters we will read the shortcut to execute
@@ -32,12 +33,16 @@ export class ShortcutPageComponent {
               private connection: WebsocketService,
               private router: Router,
               private store: Store<{ networkState: RoomState | undefined }>) {
-    combineLatest([this.activatedRoute.queryParams, this.store.select('networkState')])
+    this.storeSubscription = combineLatest([this.activatedRoute.queryParams, this.store.select('networkState')])
       .subscribe(([params, state]) => {
         if (!state) return;
 
         this.executeShortcut(params['action']);
       });
+  }
+
+  ngOnDestroy(): void {
+    this.storeSubscription.unsubscribe();
   }
 
   private executeShortcut(param: string | undefined) {

--- a/apps/website/src/app/pages/visualizer-page/visualizer-page.component.ts
+++ b/apps/website/src/app/pages/visualizer-page/visualizer-page.component.ts
@@ -15,7 +15,7 @@ import { OffCanvasComponent } from "../../shared/components/offcanvas/off-canvas
 
 import { InformationService } from "../../services/information-service/information.service";
 import { faSpotify } from "@fortawesome/free-brands-svg-icons";
-import { Store } from "@ngrx/store";
+import { Store, Subscription } from "@ngrx/store";
 import { ChangeRoomColors, ChangeRoomMode } from "../../../redux/roomstate/roomstate.action";
 import { WebsocketService } from "../../services/websocketconnection/websocket.service";
 import { areColorsSimilar, mapNumber } from '../../shared/functions';
@@ -105,6 +105,9 @@ export class VisualizerPageComponent implements OnDestroy {
   private spotifyPlaybackState: Spotify.PlaybackState | undefined;
   private albumCoverHTMLElement: HTMLImageElement | undefined;
   public reactiveModes: ModeInformation[] = [];
+  private userPreferencesSubscription: Subscription;
+  private gradientsSubscription: Subscription;
+  private modesSubscription: Subscription;
 
 
   constructor(
@@ -120,6 +123,9 @@ export class VisualizerPageComponent implements OnDestroy {
       modes: ModeInformation[],
     }>
   ) {
+    this.userPreferencesSubscription = this.store.select("userPreferences").pipe(map(userPref => userPref.visualizerOptions)).subscribe();
+    this.gradientsSubscription = this.store.select("gradients").pipe(skipWhile(gradients => gradients.length === 0)).subscribe();
+    this.modesSubscription = this.store.select("modes").subscribe();
   }
 
   /**
@@ -171,6 +177,9 @@ export class VisualizerPageComponent implements OnDestroy {
     this.wakeLock?.release()
       .then()
       .catch((error: Error) => console.error("Failed to release wake lock", error));
+    this.userPreferencesSubscription.unsubscribe();
+    this.gradientsSubscription.unsubscribe();
+    this.modesSubscription.unsubscribe();
   }
 
   drawCallback(instance: AudioMotionAnalyzer): void {

--- a/apps/website/src/app/pages/visualizer-page/visualizer-page.component.ts
+++ b/apps/website/src/app/pages/visualizer-page/visualizer-page.component.ts
@@ -15,12 +15,12 @@ import { OffCanvasComponent } from "../../shared/components/offcanvas/off-canvas
 
 import { InformationService } from "../../services/information-service/information.service";
 import { faSpotify } from "@fortawesome/free-brands-svg-icons";
-import { Store, Subscription } from "@ngrx/store";
+import { Store } from "@ngrx/store";
 import { ChangeRoomColors, ChangeRoomMode } from "../../../redux/roomstate/roomstate.action";
 import { WebsocketService } from "../../services/websocketconnection/websocket.service";
 import { areColorsSimilar, mapNumber } from '../../shared/functions';
 import { AngulonVisualizerOptions, UserPreferences } from "../../shared/types/types";
-import { combineLatest, distinctUntilChanged, map, skipWhile } from "rxjs";
+import { combineLatest, distinctUntilChanged, map, skipWhile, Subscription } from 'rxjs';
 import { ChangeVisualizerOptions } from "../../../redux/user-preferences/user-preferences.action";
 import { CommonModule } from "@angular/common";
 import { FormsModule } from "@angular/forms";

--- a/apps/website/src/app/services/theme/theme.service.ts
+++ b/apps/website/src/app/services/theme/theme.service.ts
@@ -9,8 +9,8 @@ import { Subscription } from 'rxjs';
 })
 export class ThemeService implements OnDestroy {
   private _theme = '';
-  private userPreferencesSubscription: Subscription;
-  
+  private userPreferencesSubscription: Subscription | undefined;
+
   get theme(): string {
     return this._theme;
   }
@@ -44,7 +44,7 @@ export class ThemeService implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.userPreferencesSubscription.unsubscribe();
+    this.userPreferencesSubscription?.unsubscribe();
   }
 
   /**

--- a/apps/website/src/app/services/theme/theme.service.ts
+++ b/apps/website/src/app/services/theme/theme.service.ts
@@ -1,13 +1,16 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { UserPreferences } from '../../shared/types/types';
 import { ThemeColors } from '../../shared/functions';
+import { Subscription } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
-export class ThemeService {
+export class ThemeService implements OnDestroy {
   private _theme = '';
+  private userPreferencesSubscription: Subscription;
+  
   get theme(): string {
     return this._theme;
   }
@@ -18,7 +21,7 @@ export class ThemeService {
   }
 
   initialize(): void {
-    this.store.select('userPreferences').subscribe(userPreferences => {
+    this.userPreferencesSubscription = this.store.select('userPreferences').subscribe(userPreferences => {
       this.applyTheme(userPreferences.settings.theme);
     });
   }
@@ -38,6 +41,10 @@ export class ThemeService {
     metaTag?.setAttribute('content', `oklch(${primaryColor}`);
 
     this._theme = theme;
+  }
+
+  ngOnDestroy(): void {
+    this.userPreferencesSubscription.unsubscribe();
   }
 
   /**

--- a/apps/website/src/app/shared/components/colorpicker/colorpicker.component.ts
+++ b/apps/website/src/app/shared/components/colorpicker/colorpicker.component.ts
@@ -31,7 +31,7 @@ export class ColorpickerComponent implements AfterViewInit, OnDestroy {
     wheelAngle: 0,
     layout: this.getActiveColorPickerLayout(),
   };
-  private networkStateSubscription: Subscription;
+  private networkStateSubscription!: Subscription;
 
   isEnabled = true;
 

--- a/apps/website/src/app/shared/components/colorpicker/colorpicker.component.ts
+++ b/apps/website/src/app/shared/components/colorpicker/colorpicker.component.ts
@@ -1,11 +1,11 @@
-import {AfterViewInit, Component, Input} from '@angular/core';
+import {AfterViewInit, Component, Input, OnDestroy} from '@angular/core';
 import iro from '@jaames/iro';
 import {IroColorPicker} from '@jaames/iro/dist/ColorPicker';
-import {Store} from '@ngrx/store';
-import {ChangeRoomColors} from '../../../../redux/roomstate/roomstate.action';
-import {ClientNetworkState} from '../../../../redux/networkstate/ClientNetworkState';
-import {getStateOfSelectedRooms} from '../../functions';
-import {skip} from 'rxjs';
+import {Store}from '@ngrx/store';
+import {ChangeRoomColors}from '../../../../redux/roomstate/roomstate.action';
+import {ClientNetworkState}from '../../../../redux/networkstate/ClientNetworkState';
+import {getStateOfSelectedRooms}from '../../functions';
+import {skip, Subscription}from 'rxjs';
 
 
 export type ColorPickerOptions = Parameters<typeof iro.ColorPicker>[1];
@@ -17,7 +17,7 @@ export type ColorPickerLayoutOptions = ColorPickerOptions['layout'];
   templateUrl: './colorpicker.component.html',
   styleUrls: ['./colorpicker.component.scss']
 })
-export class ColorpickerComponent implements AfterViewInit {
+export class ColorpickerComponent implements AfterViewInit, OnDestroy {
   @Input() orientation: 'horizontal' | 'vertical' = 'horizontal';
   protected id = this.generateElementId();
   private picker!: IroColorPicker;
@@ -31,6 +31,7 @@ export class ColorpickerComponent implements AfterViewInit {
     wheelAngle: 0,
     layout: this.getActiveColorPickerLayout(),
   };
+  private networkStateSubscription: Subscription;
 
   isEnabled = true;
 
@@ -45,7 +46,7 @@ export class ColorpickerComponent implements AfterViewInit {
     // Skip the first value as it contains the initial state of the redux store but it won't contain the server-side state yet.
     // We will receive that later, once the WS connection has been established
     // This also fixes the Angular error "ExpressionChangedAfterItHasBeenCheckedError"
-    this.store.select('networkState').pipe(skip(1)).subscribe((state) => {
+    this.networkStateSubscription = this.store.select('networkState').pipe(skip(1)).subscribe((state) => {
       if (!state) return;
 
       // Find the current state of the selected rooms by taking the first selected room
@@ -76,6 +77,10 @@ export class ColorpickerComponent implements AfterViewInit {
       this.skipSettingColors = true;
       this.store.dispatch(new ChangeRoomColors(colors));
     });
+  }
+
+  ngOnDestroy(): void {
+    this.networkStateSubscription.unsubscribe();
   }
 
   /**


### PR DESCRIPTION
Related to #188

Add `OnDestroy` lifecycle hook to unsubscribe from store subscriptions in various components.

* **NavigationbarComponent**:
  - Add `OnDestroy` to the component's class.
  - Implement `ngOnDestroy` lifecycle hook.
  - Unsubscribe from the `networkState` store subscription in `ngOnDestroy`.

* **HomePageComponent**:
  - Add `OnDestroy` to the component's class.
  - Implement `ngOnDestroy` lifecycle hook.
  - Unsubscribe from the `networkState` store subscription in `ngOnDestroy`.

* **VisualizerPageComponent**:
  - Add `OnDestroy` to the component's class.
  - Implement `ngOnDestroy` lifecycle hook.
  - Unsubscribe from the `userPreferences`, `gradients`, and `modes` store subscriptions in `ngOnDestroy`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Staijn1/phos/issues/188?shareId=bdbbe2b0-4ef0-4e23-b77e-6af8608b25d7).