### PR TITLE
Add ability to disable setting secondary color to album cover when using Spotify Mode

### DIFF
--- a/apps/api/src/app/room/room.service.ts
+++ b/apps/api/src/app/room/room.service.ts
@@ -1,16 +1,16 @@
-import {Injectable, Logger, OnModuleDestroy} from '@nestjs/common';
+import {Injectable, Logger} from '@nestjs/common';
 import {DAOService} from '../interfaces/DAOService';
 import {Room} from './Room.model';
-import {FindManyOptions, FindOneOptions, FindOptionsWhere, In, Repository}from 'typeorm';
-import {InjectRepository}from '@nestjs/typeorm';
-import {validate}from 'class-validator';
-import {DeviceService}from '../device/device.service';
-import {INITIAL_ROOM_STATE, IRoom, RoomsState, RoomState}from '@angulon/interfaces';
-import {debounceTime, Subject}from 'rxjs';
+import {FindManyOptions, FindOneOptions, FindOptionsWhere, In, Repository} from 'typeorm';
+import {InjectRepository} from '@nestjs/typeorm';
+import {validate} from 'class-validator';
+import {DeviceService} from '../device/device.service';
+import {INITIAL_ROOM_STATE, IRoom, RoomsState, RoomState} from '@angulon/interfaces';
+import {debounceTime, Subject} from 'rxjs';
 
 
 @Injectable()
-export class RoomService implements DAOService<Room>, OnModuleDestroy {
+export class RoomService implements DAOService<Room> {
   private readonly logger = new Logger(RoomService.name);
 
   /**
@@ -139,9 +139,5 @@ export class RoomService implements DAOService<Room>, OnModuleDestroy {
    */
   async updateRoomStateForRooms(rooms: string[], newState: RoomState) {
     await this.updateMany({id: In(rooms)}, {state: newState});
-  }
-
-  onModuleDestroy() {
-    this.updateRoomStateForRoomsSubject.unsubscribe();
   }
 }

--- a/apps/website/src/app/main/app/app.component.ts
+++ b/apps/website/src/app/main/app/app.component.ts
@@ -1,18 +1,17 @@
-import {Component, HostListener, OnInit, ViewChild, OnDestroy} from '@angular/core';
+import {Component, HostListener, OnInit, ViewChild} from '@angular/core';
 import {SwUpdate} from '@angular/service-worker';
 import {MessageService} from '../../services/message-service/message.service';
-import {ThemeService}from '../../services/theme/theme.service';
-import {Message}from '../../shared/types/Message';
-import {swipeRight}from '@angulon/ui';
+import {ThemeService} from '../../services/theme/theme.service';
+import {Message} from '../../shared/types/Message';
+import {swipeRight} from '@angulon/ui';
 import * as AOS from 'aos';
-import {UserPreferences}from '../../shared/types/types';
-import {Store}from '@ngrx/store';
-import {BaseChromaConnection}from '../../services/chroma-sdk/base-chroma-connection.service';
-import {NavigationEnd, NavigationStart, Router}from '@angular/router';
-import {gsap}from 'gsap';
-import {OffCanvasComponent}from '../../shared/components/offcanvas/off-canvas.component';
-import {faBars as OpenMobileMenuIcon, faTimes as CloseMobileMenuIcon}from '@fortawesome/free-solid-svg-icons';
-import { Subscription } from 'rxjs';
+import {UserPreferences} from '../../shared/types/types';
+import {Store} from '@ngrx/store';
+import {BaseChromaConnection} from '../../services/chroma-sdk/base-chroma-connection.service';
+import {NavigationEnd, NavigationStart, Router} from '@angular/router';
+import {gsap} from 'gsap';
+import {OffCanvasComponent} from '../../shared/components/offcanvas/off-canvas.component';
+import {faBars as OpenMobileMenuIcon, faTimes as CloseMobileMenuIcon} from '@fortawesome/free-solid-svg-icons';
 
 @Component({
   selector: 'app-root',
@@ -20,11 +19,10 @@ import { Subscription } from 'rxjs';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent implements OnInit, OnDestroy {
+export class AppComponent implements OnInit {
   @ViewChild('mobileMenu') mobileMenu!: OffCanvasComponent;
   readonly timeline = gsap.timeline();
   private animationMode = 0;
-  private routerSubscription!: Subscription;
 
   mobileMenuIcon = OpenMobileMenuIcon;
 
@@ -80,7 +78,7 @@ export class AppComponent implements OnInit, OnDestroy {
     AOS.init();
 
     // Subscribe to router events so we can display a page transition animation each time the user navigates to a new page.
-    this.routerSubscription = this.router.events.subscribe((val) => {
+    this.router.events.subscribe((val) => {
       // When the user starts to navigate to a new page, immediately show the cover again otherwise content will already be visible.
       if (val instanceof NavigationStart) {
         gsap.set('#cover', { autoAlpha: 1, duration: 0.3 });
@@ -90,10 +88,6 @@ export class AppComponent implements OnInit, OnDestroy {
         this.mobileMenu.close();
       }
     });
-  }
-
-  ngOnDestroy(): void {
-    this.routerSubscription.unsubscribe();
   }
 
   private animationFromLeft(): void {

--- a/apps/website/src/app/main/navigationbar/navigationbar.component.ts
+++ b/apps/website/src/app/main/navigationbar/navigationbar.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, ViewChild, OnDestroy} from '@angular/core';
+import {Component, Input, ViewChild} from '@angular/core';
 import {
   faChartBar,
   faCog,
@@ -30,7 +30,7 @@ import {
   SPEED_MINIMUM_INTERVAL_MS
 } from '../../shared/constants';
 import {ClientNetworkState, WebsocketConnectionStatus} from '../../../redux/networkstate/ClientNetworkState';
-import {distinctUntilChanged, map, Subscription} from 'rxjs';
+import {distinctUntilChanged, map} from 'rxjs';
 import {getStateOfSelectedRooms} from '../../shared/functions';
 
 @Component({
@@ -38,7 +38,7 @@ import {getStateOfSelectedRooms} from '../../shared/functions';
   templateUrl: './navigationbar.component.html',
   styleUrls: ['./navigationbar.component.scss']
 })
-export class NavigationbarComponent implements OnDestroy {
+export class NavigationbarComponent {
   @ViewChild(ColorpickerComponent) colorpicker!: ColorpickerComponent;
   @Input() colorPickerOrientation: 'horizontal' | 'vertical' = 'horizontal';
 
@@ -62,8 +62,6 @@ export class NavigationbarComponent implements OnDestroy {
 
   websocketConnectionStatus: WebsocketConnectionStatus | undefined;
   clearConnectionStatusTimeout: NodeJS.Timeout | undefined;
-
-  private networkStateSubscription: Subscription;
 
   get isDisconnected(): boolean {
     return this.websocketConnectionStatus === WebsocketConnectionStatus.DISCONNECTED;
@@ -89,7 +87,7 @@ export class NavigationbarComponent implements OnDestroy {
       networkState: ClientNetworkState
     }>
   ) {
-    this.networkStateSubscription = store.select('networkState' ).subscribe(state => {
+    store.select('networkState' ).subscribe(state => {
       const selectedRoomState = getStateOfSelectedRooms(state);
 
       // When no room is selected, disable all action buttons
@@ -126,10 +124,6 @@ export class NavigationbarComponent implements OnDestroy {
           this.clearConnectionStatusTimeout = setTimeout(() => this.websocketConnectionStatus = undefined, 5000);
         }
       });
-  }
-
-  ngOnDestroy(): void {
-    this.networkStateSubscription.unsubscribe();
   }
 
   turnOff(): void {

--- a/apps/website/src/app/pages/home-page/home-page.component.ts
+++ b/apps/website/src/app/pages/home-page/home-page.component.ts
@@ -1,17 +1,17 @@
-import { Component, HostListener, ViewChild, OnDestroy } from '@angular/core';
+import { Component, HostListener, ViewChild } from '@angular/core';
 import { IDevice, IRoom, RoomState } from '@angulon/interfaces';
 import {Store} from '@ngrx/store';
 import {MAXIMUM_BRIGHTNESS, SPEED_MAXIMUM_INTERVAL_MS} from '../../shared/constants';
 import {DecimalPipe, NgClass, NgForOf, NgIf} from '@angular/common';
 import {RadialProgressComponent} from '../../shared/components/radialprogress/radial-progress.component';
-import {SharedModule}from '../../shared/shared.module';
+import {SharedModule} from '../../shared/shared.module';
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import {PowerDrawComponent}from '../../shared/components/power-draw/power-draw.component';
+import {FontAwesomeModule} from '@fortawesome/angular-fontawesome';
+import {PowerDrawComponent} from '../../shared/components/power-draw/power-draw.component';
 import {ClientNetworkState, WebsocketConnectionStatus} from '../../../redux/networkstate/ClientNetworkState';
-import {distinctUntilChanged, map, Subscription} from 'rxjs';
+import {distinctUntilChanged, map} from 'rxjs';
 import { faTrashAlt } from '@fortawesome/free-regular-svg-icons';
 import { WebsocketService } from '../../services/websocketconnection/websocket.service';
-import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 @Component({
   selector: 'app-home',
@@ -29,7 +29,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
   ],
   standalone: true
 })
-export class HomePageComponent implements OnDestroy {
+export class HomePageComponent {
   @ViewChild(PowerDrawComponent) powerDrawComponent: PowerDrawComponent | undefined;
   protected readonly faTrash = faTrashAlt;
   protected readonly offlineWarningIcon = faTriangleExclamation;
@@ -39,12 +39,13 @@ export class HomePageComponent implements OnDestroy {
   private isChartInitialized = false;
   networkState: ClientNetworkState | undefined;
   private contextMenuDevice: IDevice | undefined;
-  private networkStateSubscription: Subscription;
+
+
 
   constructor(
     private readonly store: Store<{ roomState: RoomState, networkState: ClientNetworkState }>,
     private readonly connection: WebsocketService) {
-    this.networkStateSubscription = this.store.select('networkState').subscribe((state) => {
+    this.store.select('networkState').subscribe((state) => {
       this.networkState = state;
     });
 
@@ -60,9 +61,6 @@ export class HomePageComponent implements OnDestroy {
     });
   }
 
-  ngOnDestroy(): void {
-    this.networkStateSubscription.unsubscribe();
-  }
 
   convertSpeedToPercentage(speed: number) {
     return speed / SPEED_MAXIMUM_INTERVAL_MS * 100;

--- a/apps/website/src/app/pages/settings-page/settings-page.component.ts
+++ b/apps/website/src/app/pages/settings-page/settings-page.component.ts
@@ -1,19 +1,19 @@
-import {Component, OnInit, ViewChild, OnDestroy} from '@angular/core';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import {faTrash} from '@fortawesome/free-solid-svg-icons';
 import {GeneralSettings, UserPreferences} from '../../shared/types/types';
 import {themes} from '../../shared/constants';
-import {Store}from '@ngrx/store';
-import {ChangeGeneralSettings}from '../../../redux/user-preferences/user-preferences.action';
-import {FormsModule, NgForm}from '@angular/forms';
-import {debounceTime, skip, Subscription}from 'rxjs';
-import {ThemeVisualizationComponent}from '../../shared/components/theme-visualization/theme-visualization.component';
-import {JsonPipe, NgForOf, NgIf}from '@angular/common';
-import {FontAwesomeModule}from '@fortawesome/angular-fontawesome';
-import {IDevice, INetworkState, IRoom}from '@angulon/interfaces';
-import {WebsocketService}from '../../services/websocketconnection/websocket.service';
-import {ActivatedRoute, Router}from '@angular/router';
-import {SharedModule}from '../../shared/shared.module';
-import {CdkDrag, CdkDragDrop, CdkDropList, CdkDropListGroup}from '@angular/cdk/drag-drop';
+import {Store} from '@ngrx/store';
+import {ChangeGeneralSettings} from '../../../redux/user-preferences/user-preferences.action';
+import {FormsModule, NgForm} from '@angular/forms';
+import {debounceTime, skip} from 'rxjs';
+import {ThemeVisualizationComponent} from '../../shared/components/theme-visualization/theme-visualization.component';
+import {JsonPipe, NgForOf, NgIf} from '@angular/common';
+import {FontAwesomeModule} from '@fortawesome/angular-fontawesome';
+import {IDevice, INetworkState, IRoom} from '@angulon/interfaces';
+import {WebsocketService} from '../../services/websocketconnection/websocket.service';
+import {ActivatedRoute, Router} from '@angular/router';
+import {SharedModule} from '../../shared/shared.module';
+import {CdkDrag, CdkDragDrop, CdkDropList, CdkDropListGroup} from '@angular/cdk/drag-drop';
 
 @Component({
   selector: 'app-settings',
@@ -33,7 +33,7 @@ import {CdkDrag, CdkDragDrop, CdkDropList, CdkDropListGroup}from '@angular/cdk/d
   ],
   standalone: true
 })
-export class SettingsPageComponent implements OnInit, OnDestroy {
+export class SettingsPageComponent implements OnInit {
   @ViewChild('form', {static: true}) form!: NgForm;
   settings: GeneralSettings | undefined;
   selectedTheme = 0;
@@ -42,8 +42,6 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
   activeMenu = 0;
   networkState: INetworkState | undefined;
   trashIcon = faTrash;
-  private userPreferencesSubscription: Subscription;
-  private networkStateSubscription: Subscription;
 
   constructor(
     private readonly router: Router,
@@ -53,14 +51,14 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
       userPreferences: UserPreferences,
       networkState: INetworkState,
     }>) {
-    this.userPreferencesSubscription = this.store.select('userPreferences').subscribe(preferences => {
+    this.store.select('userPreferences').subscribe(preferences => {
       if (this.skipFormUpdate) return;
 
       this.settings = structuredClone(preferences.settings);
       this.selectedTheme = this.availableThemes.findIndex(theme => theme === preferences.settings.theme);
     });
 
-    this.networkStateSubscription = this.store.select('networkState').subscribe(networkState => {
+    this.store.select('networkState').subscribe(networkState => {
       this.networkState = networkState;
     });
   }
@@ -79,11 +77,6 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
         this.activeMenu = parseInt(fragment);
       }
     });
-  }
-
-  ngOnDestroy(): void {
-    this.userPreferencesSubscription.unsubscribe();
-    this.networkStateSubscription.unsubscribe();
   }
 
   setTheme(theme: string): void {

--- a/apps/website/src/app/pages/shortcut-page/shortcut-page.component.ts
+++ b/apps/website/src/app/pages/shortcut-page/shortcut-page.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnDestroy } from '@angular/core';
+import { Component } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from "@angular/router";
 import { MessageService } from '../../services/message-service/message.service';
 import { Store } from '@ngrx/store';
 import { RoomState } from '@angulon/interfaces';
-import { combineLatest, Subscription } from 'rxjs';
+import { combineLatest } from 'rxjs';
 import { WebsocketService } from '../../services/websocketconnection/websocket.service';
 import {
   DecreaseRoomBrightness,
@@ -21,9 +21,8 @@ import {
   ],
   standalone: true
 })
-export class ShortcutPageComponent implements OnDestroy {
+export class ShortcutPageComponent {
   private static wasShortcutActivated = false;
-  private storeSubscription: Subscription;
 
   /**
    * From the query parameters we will read the shortcut to execute
@@ -33,16 +32,12 @@ export class ShortcutPageComponent implements OnDestroy {
               private connection: WebsocketService,
               private router: Router,
               private store: Store<{ networkState: RoomState | undefined }>) {
-    this.storeSubscription = combineLatest([this.activatedRoute.queryParams, this.store.select('networkState')])
+    combineLatest([this.activatedRoute.queryParams, this.store.select('networkState')])
       .subscribe(([params, state]) => {
         if (!state) return;
 
         this.executeShortcut(params['action']);
       });
-  }
-
-  ngOnDestroy(): void {
-    this.storeSubscription.unsubscribe();
   }
 
   private executeShortcut(param: string | undefined) {

--- a/apps/website/src/app/pages/visualizer-page/visualizer-page.component.html
+++ b/apps/website/src/app/pages/visualizer-page/visualizer-page.component.html
@@ -10,10 +10,13 @@
           <fa-icon [icon]="fullscreenIcon"></fa-icon>
         </button>
         <div class="tw-dropdown">
-          <label tabindex="0" class="tw-btn tw-btn-primary  tw-join-item"><fa-icon [icon]="modeIcon"></fa-icon></label>
-          <ul tabindex="0" class="tw-dropdown-content z-[1] tw-menu tw-p-2 tw-shadow tw-bg-base-100 tw-rounded-box tw-w-52">
+          <label tabindex="0" class="tw-btn tw-btn-primary  tw-join-item">
+            <fa-icon [icon]="modeIcon"></fa-icon>
+          </label>
+          <ul tabindex="0"
+              class="tw-dropdown-content z-[1] tw-menu tw-p-2 tw-shadow tw-bg-base-100 tw-rounded-box tw-w-52">
             <li *ngFor="let mode of reactiveModes">
-              <a (click)="setMode(mode.mode)">{{mode.name}}</a>
+              <a (click)="setMode(mode.mode)">{{ mode.name }}</a>
             </li>
           </ul>
         </div>
@@ -59,7 +62,7 @@
             </label>
             <select (change)="applySettings()" [(ngModel)]="visualizerOptions.gradientLeft"
                     class="tw-select focus:tw-select-primary tw-select-bordered">
-              <option *ngFor="let gradient of gradients" [ngValue]="gradient.name">{{gradient.name}}</option>
+              <option *ngFor="let gradient of gradients" [ngValue]="gradient.name">{{ gradient.name }}</option>
             </select>
           </div>
 
@@ -70,7 +73,7 @@
             </label>
             <select (change)="applySettings()" [(ngModel)]="visualizerOptions.gradientRight"
                     class="tw-select focus:tw-select-primary tw-select-bordered">
-              <option *ngFor="let gradient of gradients" [ngValue]="gradient.name">{{gradient.name}}</option>
+              <option *ngFor="let gradient of gradients" [ngValue]="gradient.name">{{ gradient.name }}</option>
             </select>
           </div>
 
@@ -81,7 +84,7 @@
             </label>
             <select (change)="applySettings()" [(ngModel)]="visualizerOptions.mode"
                     class="tw-select focus:tw-select-primary tw-select-bordered">
-              <option *ngFor="let mode of visualizerModes" [ngValue]="mode.value">{{mode.text}}</option>
+              <option *ngFor="let mode of visualizerModes" [ngValue]="mode.value">{{ mode.text }}</option>
             </select>
           </div>
 
@@ -203,7 +206,8 @@
           <div class="tw-form-control">
             <label class="tw-label tw-cursor-pointer">
               <span class="tw-label-text">Peak Fade</span>
-              <input (change)="applySettings()" [(ngModel)]="visualizerOptions.fadePeaks" [disabled]="!visualizerOptions.showPeaks"
+              <input (change)="applySettings()" [(ngModel)]="visualizerOptions.fadePeaks"
+                     [disabled]="!visualizerOptions.showPeaks"
                      class="tw-checkbox tw-checkbox-sm tw-checkbox-primary" type="checkbox" id="fadePeaks" />
             </label>
           </div>
@@ -339,23 +343,25 @@
 
       </div>
       <div class="tab-content" [class.active-tab]="activeTab === 3">
-        <div>
-          <app-spotify-player (playbackChanged)="onSpotifyStateChanged($event)"></app-spotify-player>
+        @if (settings && spotifyAuth.isLoggedIn()) {
+            <div class="tw-form-control tw-w-full tw-max-w-xs tw-mt-5">
+              <label class="tw-label">
+                <span class="tw-label-text">Disable Secondary Color</span>
+                <input type="checkbox" class="tw-toggle tw-toggle-primary"
+                       [(ngModel)]="settings.disableSecondaryColorSpotify"
+                       (change)="onSecondaryColorSpotifySettingChange()">
+              </label>
+            </div>
+        }
+        <app-spotify-player (playbackChanged)="onSpotifyStateChanged($event)"></app-spotify-player>
 
-          <div class="tw-mt-5" *ngIf="!spotifyAuth.isLoggedIn()">
-            <p>
-              With the Spotify Integration, the visualizer and ledstrip(s) will automatically adjust to the dominant
-              colors in the album-cover of the song you are currently listening.
-            </p>
-            <p class="tw-mt-5">To get started, log in first. Then, in the Spotify app select "Phos" under the list of
-              devices. Then let the magic happen!</p>
-          </div>
-          <div class="tw-form-control tw-w-full tw-max-w-xs tw-mt-5">
-            <label class="tw-label">
-              <span class="tw-label-text">Disable Secondary Color</span>
-              <input type="checkbox" class="tw-toggle tw-toggle-primary" [(ngModel)]="userPreferences.disableSecondaryColorSpotify" (change)="applySettings()">
-            </label>
-          </div>
+        <div class="tw-mt-5" *ngIf="!spotifyAuth.isLoggedIn()">
+          <p>
+            With the Spotify Integration, the visualizer and ledstrip(s) will automatically adjust to the dominant
+            colors in the album-cover of the song you are currently listening.
+          </p>
+          <p class="tw-mt-5">To get started, log in first. Then, in the Spotify app select "Phos" under the list of
+            devices. Then let the magic happen!</p>
         </div>
       </div>
     </div>

--- a/apps/website/src/app/pages/visualizer-page/visualizer-page.component.html
+++ b/apps/website/src/app/pages/visualizer-page/visualizer-page.component.html
@@ -350,6 +350,12 @@
             <p class="tw-mt-5">To get started, log in first. Then, in the Spotify app select "Phos" under the list of
               devices. Then let the magic happen!</p>
           </div>
+          <div class="tw-form-control tw-w-full tw-max-w-xs tw-mt-5">
+            <label class="tw-label">
+              <span class="tw-label-text">Disable Secondary Color</span>
+              <input type="checkbox" class="tw-toggle tw-toggle-primary" [(ngModel)]="userPreferences.disableSecondaryColorSpotify" (change)="applySettings()">
+            </label>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/website/src/app/pages/visualizer-page/visualizer-page.component.ts
+++ b/apps/website/src/app/pages/visualizer-page/visualizer-page.component.ts
@@ -20,7 +20,7 @@ import { ChangeRoomColors, ChangeRoomMode } from "../../../redux/roomstate/rooms
 import { WebsocketService } from "../../services/websocketconnection/websocket.service";
 import { areColorsSimilar, mapNumber } from '../../shared/functions';
 import { AngulonVisualizerOptions, UserPreferences } from "../../shared/types/types";
-import { combineLatest, distinctUntilChanged, map, skipWhile, Subscription } from 'rxjs';
+import { combineLatest, distinctUntilChanged, map, skipWhile } from "rxjs";
 import { ChangeVisualizerOptions } from "../../../redux/user-preferences/user-preferences.action";
 import { CommonModule } from "@angular/common";
 import { FormsModule } from "@angular/forms";
@@ -105,10 +105,6 @@ export class VisualizerPageComponent implements OnDestroy {
   private spotifyPlaybackState: Spotify.PlaybackState | undefined;
   private albumCoverHTMLElement: HTMLImageElement | undefined;
   public reactiveModes: ModeInformation[] = [];
-  private userPreferencesSubscription: Subscription;
-  private gradientsSubscription: Subscription;
-  private modesSubscription: Subscription;
-  private userPreferences: UserPreferences;
 
 
   constructor(
@@ -124,12 +120,6 @@ export class VisualizerPageComponent implements OnDestroy {
       modes: ModeInformation[],
     }>
   ) {
-    this.userPreferencesSubscription = this.store.select("userPreferences").pipe(map(userPref => userPref.visualizerOptions)).subscribe();
-    this.gradientsSubscription = this.store.select("gradients").pipe(skipWhile(gradients => gradients.length === 0)).subscribe();
-    this.modesSubscription = this.store.select("modes").subscribe();
-    this.userPreferencesSubscription = this.store.select("userPreferences").subscribe(userPreferences => {
-      this.userPreferences = userPreferences;
-    });
   }
 
   /**
@@ -181,9 +171,6 @@ export class VisualizerPageComponent implements OnDestroy {
     this.wakeLock?.release()
       .then()
       .catch((error: Error) => console.error("Failed to release wake lock", error));
-    this.userPreferencesSubscription.unsubscribe();
-    this.gradientsSubscription.unsubscribe();
-    this.modesSubscription.unsubscribe();
   }
 
   drawCallback(instance: AudioMotionAnalyzer): void {
@@ -289,10 +276,11 @@ export class VisualizerPageComponent implements OnDestroy {
             }
           ];
 
-          const gradient: GradientOptions = {
+          const gradient: GradientInformation = {
             name: "spotify",
             id: 999,
-            colors: colorsStops
+            bgColor: "#000",
+            colorStops: colorsStops
           };
 
           this.store.dispatch(new RegisterGradientAction({ ...gradient, name: "spotify", id: 999 }));

--- a/apps/website/src/app/pages/visualizer-page/visualizer-page.component.ts
+++ b/apps/website/src/app/pages/visualizer-page/visualizer-page.component.ts
@@ -108,6 +108,7 @@ export class VisualizerPageComponent implements OnDestroy {
   private userPreferencesSubscription: Subscription;
   private gradientsSubscription: Subscription;
   private modesSubscription: Subscription;
+  private userPreferences: UserPreferences;
 
 
   constructor(
@@ -126,6 +127,9 @@ export class VisualizerPageComponent implements OnDestroy {
     this.userPreferencesSubscription = this.store.select("userPreferences").pipe(map(userPref => userPref.visualizerOptions)).subscribe();
     this.gradientsSubscription = this.store.select("gradients").pipe(skipWhile(gradients => gradients.length === 0)).subscribe();
     this.modesSubscription = this.store.select("modes").subscribe();
+    this.userPreferencesSubscription = this.store.select("userPreferences").subscribe(userPreferences => {
+      this.userPreferences = userPreferences;
+    });
   }
 
   /**
@@ -286,16 +290,22 @@ export class VisualizerPageComponent implements OnDestroy {
           ];
 
           const gradient: GradientOptions = {
-            bgColor: "#000",
-            colorStops: colorsStops
+            name: "spotify",
+            id: 999,
+            colors: colorsStops
           };
 
-          this.store.dispatch(new ChangeRoomColors([new iro.Color(primaryColor), new iro.Color(secondaryColor)]));
           this.store.dispatch(new RegisterGradientAction({ ...gradient, name: "spotify", id: 999 }));
 
           this.visualizerOptions.gradientLeft = "spotify";
           this.visualizerOptions.gradientRight = "spotify";
           this.applySettings();
+
+          const roomColors = [new iro.Color(primaryColor)];
+          if (!this.userPreferences.settings.disableSecondaryColorSpotify) {
+            roomColors.push(new iro.Color(secondaryColor));
+          }
+          this.store.dispatch(new ChangeRoomColors(roomColors));
         });
       }
     }

--- a/apps/website/src/app/pages/visualizer-page/visualizer-page.component.ts
+++ b/apps/website/src/app/pages/visualizer-page/visualizer-page.component.ts
@@ -21,7 +21,10 @@ import { WebsocketService } from "../../services/websocketconnection/websocket.s
 import { areColorsSimilar, mapNumber } from '../../shared/functions';
 import { AngulonVisualizerOptions, GeneralSettings, UserPreferences } from '../../shared/types/types';
 import { combineLatest, distinctUntilChanged, map, skipWhile, Subscription } from 'rxjs';
-import { ChangeVisualizerOptions } from "../../../redux/user-preferences/user-preferences.action";
+import {
+  ChangeGeneralSettings,
+  ChangeVisualizerOptions
+} from '../../../redux/user-preferences/user-preferences.action';
 import { CommonModule } from "@angular/common";
 import { FormsModule } from "@angular/forms";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
@@ -106,7 +109,7 @@ export class VisualizerPageComponent implements OnDestroy {
   private albumCoverHTMLElement: HTMLImageElement | undefined;
   public reactiveModes: ModeInformation[] = [];
   private settingsSubcription!: Subscription;
-  private settings!: GeneralSettings;
+  protected settings!: GeneralSettings;
   private modesSubscription!: Subscription;
 
 
@@ -145,7 +148,7 @@ export class VisualizerPageComponent implements OnDestroy {
     });
 
     this.settingsSubcription = this.store.select("userPreferences").pipe(map(x => x.settings)).subscribe(settings => {
-      this.settings = settings;
+      this.settings = structuredClone(settings);
     });
 
     combineLatest([
@@ -241,6 +244,10 @@ export class VisualizerPageComponent implements OnDestroy {
 
   applySettings() {
     this.store.dispatch(new ChangeVisualizerOptions(this.visualizerOptions));
+  }
+
+  onSecondaryColorSpotifySettingChange():void {
+    this.store.dispatch(new ChangeGeneralSettings(this.settings));
   }
 
   closeOffcanvas() {

--- a/apps/website/src/app/services/chroma-sdk/base-chroma-connection.service.ts
+++ b/apps/website/src/app/services/chroma-sdk/base-chroma-connection.service.ts
@@ -1,8 +1,8 @@
-import { inject, Injectable, OnDestroy } from "@angular/core";
+import { inject, Injectable } from "@angular/core";
 import { MessageService } from "../message-service/message.service";
 import { Store } from "@ngrx/store";
 import { UserPreferences } from "../../shared/types/types";
-import { combineLatest, debounceTime, distinctUntilChanged, map, Subscription } from "rxjs";
+import { combineLatest, debounceTime, distinctUntilChanged, map } from "rxjs";
 import {
   ChromaHeadsetEffectType,
   ChromaKeyboardEffectType,
@@ -25,7 +25,7 @@ import { InverseDoubleVuMeterChromaSDKEffect } from "./effects/InverseDoubleVuMe
  * To abstract away the connection type, this class provides a common interface for both types of connections, with some common methods already implemented.
  */
 @Injectable({ providedIn: "root" })
-export abstract class BaseChromaConnection implements OnDestroy {
+export abstract class BaseChromaConnection {
   protected readonly messageService = inject(MessageService);
   protected readonly store: Store<{
     userPreferences: UserPreferences,
@@ -46,7 +46,6 @@ export abstract class BaseChromaConnection implements OnDestroy {
   };
   protected isInitialized = false;
   protected activeEffect: BaseChromaSDKEffect | undefined;
-  private chromaSupportSubscription: Subscription;
 
   set intensity(value: number) {
     if (
@@ -61,7 +60,7 @@ export abstract class BaseChromaConnection implements OnDestroy {
     // Also subscribes to changes in the LED strip state to receive changes in the mode.
     // That way we can initialize/uninitialize the Chroma SDK when the setting is changed,
     // and also look up the associated effect for the selected mode and activate it immediately.
-    this.chromaSupportSubscription = combineLatest([
+    combineLatest([
       this.store.select("userPreferences").pipe(
         map(preferences => preferences.settings.chromaSupportEnabled),
         distinctUntilChanged()
@@ -92,10 +91,6 @@ export abstract class BaseChromaConnection implements OnDestroy {
       });
 
     this.registerEffects();
-  }
-
-  ngOnDestroy(): void {
-    this.chromaSupportSubscription.unsubscribe();
   }
 
   /**

--- a/apps/website/src/app/services/theme/theme.service.ts
+++ b/apps/website/src/app/services/theme/theme.service.ts
@@ -1,16 +1,13 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { UserPreferences } from '../../shared/types/types';
 import { ThemeColors } from '../../shared/functions';
-import { Subscription } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
-export class ThemeService implements OnDestroy {
+export class ThemeService {
   private _theme = '';
-  private userPreferencesSubscription: Subscription | undefined;
-
   get theme(): string {
     return this._theme;
   }
@@ -21,7 +18,7 @@ export class ThemeService implements OnDestroy {
   }
 
   initialize(): void {
-    this.userPreferencesSubscription = this.store.select('userPreferences').subscribe(userPreferences => {
+    this.store.select('userPreferences').subscribe(userPreferences => {
       this.applyTheme(userPreferences.settings.theme);
     });
   }
@@ -41,10 +38,6 @@ export class ThemeService implements OnDestroy {
     metaTag?.setAttribute('content', `oklch(${primaryColor}`);
 
     this._theme = theme;
-  }
-
-  ngOnDestroy(): void {
-    this.userPreferencesSubscription?.unsubscribe();
   }
 
   /**

--- a/apps/website/src/app/shared/components/colorpicker/colorpicker.component.ts
+++ b/apps/website/src/app/shared/components/colorpicker/colorpicker.component.ts
@@ -1,11 +1,11 @@
-import {AfterViewInit, Component, Input, OnDestroy} from '@angular/core';
+import {AfterViewInit, Component, Input} from '@angular/core';
 import iro from '@jaames/iro';
 import {IroColorPicker} from '@jaames/iro/dist/ColorPicker';
-import {Store}from '@ngrx/store';
-import {ChangeRoomColors}from '../../../../redux/roomstate/roomstate.action';
-import {ClientNetworkState}from '../../../../redux/networkstate/ClientNetworkState';
-import {getStateOfSelectedRooms}from '../../functions';
-import {skip, Subscription}from 'rxjs';
+import {Store} from '@ngrx/store';
+import {ChangeRoomColors} from '../../../../redux/roomstate/roomstate.action';
+import {ClientNetworkState} from '../../../../redux/networkstate/ClientNetworkState';
+import {getStateOfSelectedRooms} from '../../functions';
+import {skip} from 'rxjs';
 
 
 export type ColorPickerOptions = Parameters<typeof iro.ColorPicker>[1];
@@ -17,7 +17,7 @@ export type ColorPickerLayoutOptions = ColorPickerOptions['layout'];
   templateUrl: './colorpicker.component.html',
   styleUrls: ['./colorpicker.component.scss']
 })
-export class ColorpickerComponent implements AfterViewInit, OnDestroy {
+export class ColorpickerComponent implements AfterViewInit {
   @Input() orientation: 'horizontal' | 'vertical' = 'horizontal';
   protected id = this.generateElementId();
   private picker!: IroColorPicker;
@@ -31,7 +31,6 @@ export class ColorpickerComponent implements AfterViewInit, OnDestroy {
     wheelAngle: 0,
     layout: this.getActiveColorPickerLayout(),
   };
-  private networkStateSubscription!: Subscription;
 
   isEnabled = true;
 
@@ -46,7 +45,7 @@ export class ColorpickerComponent implements AfterViewInit, OnDestroy {
     // Skip the first value as it contains the initial state of the redux store but it won't contain the server-side state yet.
     // We will receive that later, once the WS connection has been established
     // This also fixes the Angular error "ExpressionChangedAfterItHasBeenCheckedError"
-    this.networkStateSubscription = this.store.select('networkState').pipe(skip(1)).subscribe((state) => {
+    this.store.select('networkState').pipe(skip(1)).subscribe((state) => {
       if (!state) return;
 
       // Find the current state of the selected rooms by taking the first selected room
@@ -77,10 +76,6 @@ export class ColorpickerComponent implements AfterViewInit, OnDestroy {
       this.skipSettingColors = true;
       this.store.dispatch(new ChangeRoomColors(colors));
     });
-  }
-
-  ngOnDestroy(): void {
-    this.networkStateSubscription.unsubscribe();
   }
 
   /**

--- a/apps/website/src/app/shared/types/types.ts
+++ b/apps/website/src/app/shared/types/types.ts
@@ -10,6 +10,7 @@ export type GeneralSettings = {
   chromaSupportEnabled: boolean;
   theme: string;
   deviceName: string;
+  disableSecondaryColorSpotify: boolean; // This setting disables the secondary color based on the album cover colors when using Spotify Integration
 };
 
 export type RGBObject = {
@@ -18,8 +19,7 @@ export type RGBObject = {
   b?: number;
 }
 
-
 export type UserPreferences = {
   settings: GeneralSettings,
-  visualizerOptions: AngulonVisualizerOptions
+  visualizerOptions: AngulonVisualizerOptions,
 }

--- a/apps/website/src/redux/user-preferences/user-preferences.reducer.ts
+++ b/apps/website/src/redux/user-preferences/user-preferences.reducer.ts
@@ -7,7 +7,8 @@ const defaultUserPreferences: UserPreferences = {
     chromaSupportEnabled: false,
     theme: "dark",
     // A random device name
-    deviceName: Math.random().toString(36).substring(7)
+    deviceName: Math.random().toString(36).substring(7),
+    disableSecondaryColorSpotify: false // P5817
   },
   visualizerOptions: {
     barSpace: 0.1,


### PR DESCRIPTION
Related to #203

Add a switch to enable/disable setting the secondary color based on the album cover colors in the Spotify Integration.

* Add a switch above the Spotify Player on the visualizer page in `apps/website/src/app/pages/visualizer-page/visualizer-page.component.html`.
* Update `UserPreferences` type in `apps/website/src/app/shared/types/types.ts` to include a new boolean property `disableSecondaryColorSpotify`.
* Update `userPreferencesReducer` in `apps/website/src/redux/user-preferences/user-preferences.reducer.ts` to handle the new `disableSecondaryColorSpotify` property.
* Update `onSpotifyStateChanged` method in `apps/website/src/app/pages/visualizer-page/visualizer-page.component.ts` to check the `disableSecondaryColorSpotify` property before setting the secondary color.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Staijn1/phos/issues/203?shareId=4482271a-47ec-49c2-a1ae-fab36a9c7e28).